### PR TITLE
Bumped minimum required versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-product-bundles-bulk-discounts",
 	"title": "Product Bundles - Bulk Discounts for WooCommerce",
-	"version": "1.4.0",
+	"version": "2.0.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/somewherewarm/woocommerce-product-bundles-bulk-discounts.git"

--- a/product-bundles-bulk-discounts-for-woocommerce.php
+++ b/product-bundles-bulk-discounts-for-woocommerce.php
@@ -3,19 +3,19 @@
 * Plugin Name: Product Bundles - Bulk Discounts
 * Plugin URI: https://docs.woocommerce.com/document/bundles/bundles-extensions/#bulk-discounts
 * Description: Bulk quantity discounts for WooCommerce Product Bundles.
-* Version: 1.4.1
+* Version: 2.0.0
 * Author: SomewhereWarm
 * Author URI: https://somewherewarm.com/
 *
 * Text Domain: woocommerce-product-bundles-bulk-discounts
 * Domain Path: /languages/
 *
-* Requires at least: 4.4
-* Tested up to: 6.3
-* Requires PHP: 5.6
+* Requires at least: 6.2
+* Tested up to: 6.6
+* Requires PHP: 7.4
 
-* WC requires at least: 3.1
-* WC tested up to: 8.0
+* WC requires at least: 8.2
+* WC tested up to: 9.1
 *
 * Copyright: © 2017-2024 SomewhereWarm SMPC.
 * License: GNU General Public License v3.0
@@ -34,14 +34,14 @@ class WC_PB_Bulk_Discounts {
 	 *
 	 * @var string
 	 */
-	public static $version = '1.4.1';
+	public static $version = '2.0.0';
 
 	/**
 	 * Min required PB version.
 	 *
 	 * @var string
 	 */
-	public static $req_pb_version = '7.0';
+	public static $req_pb_version = '8.0';
 
 	/**
 	 * PB URL.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Product Bundles - Bulk Discounts ===
 
-Contributors: SomewhereWarm
+Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, bundles, bulk, discount, rules
 Requires at least: 6.2
 Tested up to: 6.6

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 
 Contributors: franticpsyx, SomewhereWarm
 Tags: woocommerce, product, bundles, bulk, discount, quantity, tiers, rules
-Requires at least: 4.4
-Tested up to: 6.3
-Requires PHP: 5.6
-Stable tag: 1.4.1
-WC requires at least: 3.1
-WC tested up to: 8.0
+Requires at least: 6.2
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 2.0.0
+WC requires at least: 8.2
+WC tested up to: 9.1
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -88,6 +88,12 @@ This plugin requires the official [WooCommerce Product Bundles](https://woocomme
 
 
 == Changelog ==
+
+= 2.0.0 =
+* Important - New: PHP 7.4+ is now required.
+* Important - New: WooCommerce 8.2+ is now required.
+* Important - New: WordPress 6.2+ is now required.
+* Important - New: Product Bundles 8.0+ is now required.
 
 = 1.4.1 =
 * Tweak - The Bulk Discounts mini-extension now requires Product Bundles 7.0+.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Product Bundles - Bulk Discounts ===
 
-Contributors: franticpsyx, SomewhereWarm
-Tags: woocommerce, product, bundles, bulk, discount, quantity, tiers, rules
+Contributors: SomewhereWarm
+Tags: woocommerce, bundles, bulk, discount, rules
 Requires at least: 6.2
 Tested up to: 6.6
 Requires PHP: 7.4


### PR DESCRIPTION
### Description

This PR bumps the minimum required:
- PHP version to 7.4,
- WordPress version to 6.2, 
- WooCommerce version to 8.2 and;
- Product Bundles to 8.